### PR TITLE
add standalone class selector

### DIFF
--- a/style.css
+++ b/style.css
@@ -179,6 +179,12 @@ hr {
   width: 100%;
 }
 
+.meta {
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.85em;
+}
+
 p.meta {
   color: var(--text-muted);
 }


### PR DESCRIPTION
Closes #29

Adds a standalone `.meta` class selector so the checklist bullet *Class Selector (.class)* is covered independently of the existing `p.meta` combined selector.

## Summary
- New `.meta { letter-spacing; text-transform; font-size; }` rule
- Existing `p.meta { color: var(--text-muted); }` kept for the combining bullet